### PR TITLE
Merge updates for obs-waveform and obs-move-transition

### DIFF
--- a/Casks/obs-move-transition.rb
+++ b/Casks/obs-move-transition.rb
@@ -1,8 +1,8 @@
 cask "obs-move-transition" do
-  version "3.0.1"
-  obs_site_version = "5662"
-  obs_site_file = "104544"
-  sha256 "a37811e94e1a0e8a3b57cef1bcdaad3d6cdba620a2cf1155e68d1e821499652e"
+  version "3.0.2"
+  obs_site_version = "5740"
+  obs_site_file = "105505"
+  sha256 "6e7e2e2df624231ef581d2c20859489cc4a4704a2582ba5c9165c91a5ec7780e"
 
   # Plugin *does* have releases tagged in GitHub, but the artifacts only exist on the OBS forums.
   url "https://obsproject.com/forum/resources/move.913/version/#{obs_site_version}/download?file=#{obs_site_file}"

--- a/Casks/obs-waveform.rb
+++ b/Casks/obs-waveform.rb
@@ -1,9 +1,9 @@
 cask "obs-waveform" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.8.0"
-  sha256 arm:   "5904b7f7db83e92545ed768e7d737a38408d98b603ea0e69e74952eaf7e4f95a",
-         intel: "bf8cfed3c9ac9d124258fe7f9a1ed9ebca70f8d35f2ae9d37d60d7c0df76bebd"
+  version "1.8.1"
+  sha256 arm:   "72cc9c45c6abd379a9622f8fe30cda1e40144aea656a4463be0d1ef9149fb3c1",
+         intel: "86842c3afb6b8f5403914886ceef305088c145d3311d63d75fda560f98fc2421"
 
   url "https://github.com/phandasm/waveform/releases/download/v#{version}/Waveform_v#{version}_MacOS_#{arch}.pkg",
       verified: "github.com/phandasm/waveform/"


### PR DESCRIPTION
I had an alert for a new Firebot as well, but that's a beta version so I'm skipping.